### PR TITLE
dev-utils/docbook: Fix paths in the catalog

### DIFF
--- a/dev-utils/docbook/pkg/populate-catalog.sh
+++ b/dev-utils/docbook/pkg/populate-catalog.sh
@@ -26,43 +26,43 @@ populate_xml_docbook() {
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//DTD DocBook XML CALS Table Model V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/calstblx.dtd" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/calstblx.dtd" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/soextblx.dtd" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/soextblx.dtd" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//ELEMENTS DocBook XML Information Pool V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/dbpoolx.mod" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/dbpoolx.mod" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//ELEMENTS DocBook XML Document Hierarchy V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/dbhierx.mod" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/dbhierx.mod" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//ELEMENTS DocBook XML HTML Tables V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/htmltblx.mod" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/htmltblx.mod" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//ENTITIES DocBook XML Notations V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/dbnotnx.mod" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/dbnotnx.mod" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//ENTITIES DocBook XML Character Entities V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/dbcentx.mod" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/dbcentx.mod" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "public" \
         "-//OASIS//ENTITIES DocBook XML Additional General Entities V${version}//EN" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}/dbgenent.mod" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}/dbgenent.mod" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "rewriteSystem" \
         "http://www.oasis-open.org/docbook/xml/${version}" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}" \
         ${installroot}/${vendordir}/xml/docbook
     xmlcatalog --noout --add "rewriteURI" \
         "http://www.oasis-open.org/docbook/xml/${version}" \
-        "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}" \
+        "file://${datadir}/xml/docbook/xml-dtd-${version}" \
         ${installroot}/${vendordir}/xml/docbook
 }
 
@@ -70,19 +70,19 @@ populate_xml_catalog() {
     xmlcatalog --noout --create ${installroot}/${vendordir}/xml/catalog
     xmlcatalog --noout --add "delegatePublic" \
         "-//OASIS//ENTITIES DocBook XML" \
-        "file://${installroot}/${vendordir}/xml/docbook" \
+        "file://${vendordir}/xml/docbook" \
         ${installroot}/${vendordir}/xml/catalog
     xmlcatalog --noout --add "delegatePublic" \
         "-//OASIS//DTD DocBook XML" \
-        "file://${installroot}/${vendordir}/xml/docbook" \
+        "file://${vendordir}/xml/docbook" \
         ${installroot}/${vendordir}/xml/catalog
     xmlcatalog --noout --add "delegateSystem" \
         "http://www.oasis-open.org/docbook/" \
-        "file://${installroot}/${vendordir}/xml/docbook" \
+        "file://${vendordir}/xml/docbook" \
         ${installroot}/${vendordir}/xml/catalog
     xmlcatalog --noout --add "delegateURI" \
         "http://www.oasis-open.org/docbook/" \
-        "file://${installroot}/${vendordir}/xml/docbook" \
+        "file://${vendordir}/xml/docbook" \
         ${installroot}/${vendordir}/xml/catalog
 }
 
@@ -94,19 +94,19 @@ populate_xml_retrocompatibility() {
             ${installroot}/${vendordir}/xml/docbook
         xmlcatalog --noout --add "rewriteSystem" \
             "http://www.oasis-open.org/docbook/xml/$DTDVERSION" \
-            "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}" \
+            "file://${datadir}/xml/docbook/xml-dtd-${version}" \
             ${installroot}/${vendordir}/xml/docbook
         xmlcatalog --noout --add "rewriteURI" \
             "http://www.oasis-open.org/docbook/xml/$DTDVERSION" \
-            "file://${installroot}/${datadir}/xml/docbook/xml-dtd-${version}" \
+            "file://${datadir}/xml/docbook/xml-dtd-${version}" \
             ${installroot}/${vendordir}/xml/docbook
         xmlcatalog --noout --add "delegateSystem" \
             "http://www.oasis-open.org/docbook/xml/$DTDVERSION/" \
-            "file://${installroot}/${vendordir}/xml/docbook" \
+            "file://${vendordir}/xml/docbook" \
             ${installroot}/${vendordir}/xml/catalog
         xmlcatalog --noout --add "delegateURI" \
             "http://www.oasis-open.org/docbook/xml/$DTDVERSION/" \
-            "file://${installroot}/${vendordir}/xml/docbook" \
+            "file://${vendordir}/xml/docbook" \
             ${installroot}/${vendordir}/xml/catalog
     done
 }
@@ -147,12 +147,12 @@ populate_xsl_retrocompatibility() {
     for RELEASE in 1.67.2; do
         xmlcatalog --noout --add "rewriteSystem" \
             "http://docbook.sourceforge.net/release/xsl/${RELEASE}" \
-            "${installroot}/${datadir}/xml/docbook/xsl-stylesheets-${RELEASE}" \
-            ${installroot}/${vendordir}/xml/catalog &&
+            "${datadir}/xml/docbook/xsl-stylesheets-${RELEASE}" \
+            ${installroot}/${vendordir}/xml/catalog
 
         xmlcatalog --noout --add "rewriteURI" \
             "http://docbook.sourceforge.net/release/xsl/${RELEASE}" \
-            "${installroot}/${datadir}/xml/docbook/xsl-stylesheets-${RELEASE}" \
+            "${datadir}/xml/docbook/xsl-stylesheets-${RELEASE}" \
             ${installroot}/${vendordir}/xml/catalog
     done
 }

--- a/dev-utils/docbook/stone.yml
+++ b/dev-utils/docbook/stone.yml
@@ -5,7 +5,7 @@
 #
 name        : docbook
 version     : 4.5
-release     : 1
+release     : 2
 homepage    : https://docbook.org
 upstreams   :
     - https://docbook.org/xml/4.5/docbook-xml-4.5.zip : 4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4


### PR DESCRIPTION
Fixes #61.

It makes the XML validation pass in the `xdg-utils` package.